### PR TITLE
chore: disable biome root inheritance

### DIFF
--- a/example/packages/api/biome.json
+++ b/example/packages/api/biome.json
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "files": {
     "includes": [
       "src/**",


### PR DESCRIPTION
## Summary
- mark the API biome config as non-root so workspace settings apply

## Testing
- not run